### PR TITLE
For HLS, handle multiple type of audio tracks such as stereo, 5.1, etc

### DIFF
--- a/packages/core/src/WebPlayer.ts
+++ b/packages/core/src/WebPlayer.ts
@@ -44,7 +44,7 @@ export default class WebPlayer extends EventEmitter {
         }
         break;
       case ManifestType.DASH:
-        Tech = (await import('./tech/ShakaTech')).default;
+        Tech = (await import('./tech/DashJsTech')).default;//ShakaTech')).default;
         break;
       case ManifestType.MSS:
         Tech = (await import('./tech/DashJsTech')).default;
@@ -130,6 +130,29 @@ export default class WebPlayer extends EventEmitter {
   setAudioTrack(id) {
     if (this.tech) {
       this.tech.audioTrack = id;
+    }
+  }
+
+  getAudioTrack_DEV() {
+    if (this.tech) {
+      return this.tech.audioTrack;
+    }
+  }
+
+  getAudioTracks_DEV() {
+    if (this.tech) {
+      console.log(`tech -> audioTracks num=${this.tech.audioTracks.length || -1}`);
+      this.tech.audioTracks.map(track => console.log("TRACK_-:" + JSON.stringify(track)))
+      return this.tech.audioTracks;
+    }
+  }
+
+
+  getTextTracks_DEV() {
+    if (this.tech) {
+      console.log(`tech -> textTracks num=${this.tech.textTracks.length || -1}`);
+      this.tech.textTracks.map(track => console.log("textTRACK_-:" + JSON.stringify(track)))
+      return this.tech.textTracks;
     }
   }
 

--- a/packages/core/src/WebPlayer.ts
+++ b/packages/core/src/WebPlayer.ts
@@ -44,7 +44,7 @@ export default class WebPlayer extends EventEmitter {
         }
         break;
       case ManifestType.DASH:
-        Tech = (await import('./tech/DashJsTech')).default;//ShakaTech')).default;
+        Tech = (await import('./tech/ShakaTech')).default;
         break;
       case ManifestType.MSS:
         Tech = (await import('./tech/DashJsTech')).default;

--- a/packages/core/src/WebPlayer.ts
+++ b/packages/core/src/WebPlayer.ts
@@ -133,29 +133,6 @@ export default class WebPlayer extends EventEmitter {
     }
   }
 
-  getAudioTrack_DEV() {
-    if (this.tech) {
-      return this.tech.audioTrack;
-    }
-  }
-
-  getAudioTracks_DEV() {
-    if (this.tech) {
-      console.log(`tech -> audioTracks num=${this.tech.audioTracks.length || -1}`);
-      this.tech.audioTracks.map(track => console.log("TRACK_-:" + JSON.stringify(track)))
-      return this.tech.audioTracks;
-    }
-  }
-
-
-  getTextTracks_DEV() {
-    if (this.tech) {
-      console.log(`tech -> textTracks num=${this.tech.textTracks.length || -1}`);
-      this.tech.textTracks.map(track => console.log("textTRACK_-:" + JSON.stringify(track)))
-      return this.tech.textTracks;
-    }
-  }
-
   setTextTrack(id) {
     if (this.tech) {
       this.tech.textTrack = id;

--- a/packages/core/src/tech/BaseTech.ts
+++ b/packages/core/src/tech/BaseTech.ts
@@ -208,6 +208,11 @@ export default class BaseTech extends EventEmitter {
     this.emit(PlayerEvent.AUDIO_TRACK_CHANGE);
   }
 
+  protected onTextTrackChange() {
+    this.updateState({ textTracks: this.textTracks });
+    this.emit(PlayerEvent.TEXT_TRACK_CHANGE);
+  }
+
   protected onEnded() {
     this.emit(PlayerEvent.ENDED);
     this.updateState({

--- a/packages/core/src/tech/DashJsTech.ts
+++ b/packages/core/src/tech/DashJsTech.ts
@@ -7,8 +7,8 @@ export default class MssPlayer extends BaseTech {
   constructor(opts: IBaseTechOptions) {
     super(opts);
     this.mediaPlayer = MediaPlayer().create();
-    this.mediaPlayer.initialize();
-    this.mediaPlayer.attachView(this.video);
+    // this.mediaPlayer.initialize();
+    // this.mediaPlayer.attachView(this.video);
   }
 
   load(src: string): Promise<void> {
@@ -16,9 +16,29 @@ export default class MssPlayer extends BaseTech {
       playbackState: PlaybackState.LOADING,
     });
     return new Promise((resolve, reject) => {
+      this.mediaPlayer.initialize(this.video, src, false);
+      // this.mediaPlayer.setInitialMediaSettingsFor('audio', {
+      //   audioChannelConfiguration: ['F801']
+      // })
+      this.mediaPlayer.attachView(this.video);
       this.mediaPlayer.attachSource(src);
       this.mediaPlayer.on(MediaPlayer.events.MANIFEST_LOADED, () => {
         resolve();
+      });
+      this.mediaPlayer.on(MediaPlayer.events.STREAM_INITIALIZED, () => {
+        console.log(
+          'Stream is initialized!',
+          this.mediaPlayer.getCurrentTrackFor('audio')
+        );
+        let audioTracks = this.mediaPlayer.getTracksFor('audio');
+        console.log('(-.-)__.: yo DASH, audioTracks', audioTracks);
+        this.state.audioTracks = audioTracks.map((track, idx) => ({
+          id: track.index.toString(),
+          label: `Track-${1 + idx}`,
+          language: track.lang,
+          enabled: this.audioTrack === track.index.toString(),
+        }));
+        audioTracks.map((t) => console.log(t.labels));
       });
       this.mediaPlayer.on(MediaPlayer.events.ERROR, (ev) => {
         reject(`Failed to load Mss Player`);
@@ -29,6 +49,51 @@ export default class MssPlayer extends BaseTech {
   get isLive() {
     return this.mediaPlayer.isDynamic();
   }
+
+  get audioTrack() {
+    let audioTrackId = '0';
+    let track = this.mediaPlayer.getCurrentTrackFor('audio');
+    audioTrackId = track.index.toString();
+    return audioTrackId;
+  }
+
+  set audioTrack(id) {
+    let audioTracks = this.mediaPlayer.getTracksFor('audio');
+    console.log('set audioTrack(id), id=', id);
+    let track = audioTracks.find((t) => t.index === parseInt(id));
+    console.log('Imma Try to set this track,', track);
+    console.log('Codex BufferSink Error now?');
+
+    this.mediaPlayer.setCurrentTrack(track);
+  }
+
+  get audioTracks() {
+    return this.state.audioTracks;
+  }
+
+  // get textTrack() {
+
+  // }
+
+  // set textTrack(id) {
+
+  // }
+
+  // get textTracks() {
+
+  // }
+
+  // set currentLevel(level: IVideoLevel) {
+
+  // }
+
+  // get currentLevel() {
+
+  // }
+
+  // getVideoLevels() {
+
+  // }
 
   destroy() {
     if (this.mediaPlayer) {

--- a/packages/core/src/tech/DashJsTech.ts
+++ b/packages/core/src/tech/DashJsTech.ts
@@ -7,8 +7,8 @@ export default class MssPlayer extends BaseTech {
   constructor(opts: IBaseTechOptions) {
     super(opts);
     this.mediaPlayer = MediaPlayer().create();
-    // this.mediaPlayer.initialize();
-    // this.mediaPlayer.attachView(this.video);
+    this.mediaPlayer.initialize();
+    this.mediaPlayer.attachView(this.video);
   }
 
   load(src: string): Promise<void> {
@@ -16,29 +16,9 @@ export default class MssPlayer extends BaseTech {
       playbackState: PlaybackState.LOADING,
     });
     return new Promise((resolve, reject) => {
-      this.mediaPlayer.initialize(this.video, src, false);
-      // this.mediaPlayer.setInitialMediaSettingsFor('audio', {
-      //   audioChannelConfiguration: ['F801']
-      // })
-      this.mediaPlayer.attachView(this.video);
       this.mediaPlayer.attachSource(src);
       this.mediaPlayer.on(MediaPlayer.events.MANIFEST_LOADED, () => {
         resolve();
-      });
-      this.mediaPlayer.on(MediaPlayer.events.STREAM_INITIALIZED, () => {
-        console.log(
-          'Stream is initialized!',
-          this.mediaPlayer.getCurrentTrackFor('audio')
-        );
-        let audioTracks = this.mediaPlayer.getTracksFor('audio');
-        console.log('(-.-)__.: yo DASH, audioTracks', audioTracks);
-        this.state.audioTracks = audioTracks.map((track, idx) => ({
-          id: track.index.toString(),
-          label: `Track-${1 + idx}`,
-          language: track.lang,
-          enabled: this.audioTrack === track.index.toString(),
-        }));
-        audioTracks.map((t) => console.log(t.labels));
       });
       this.mediaPlayer.on(MediaPlayer.events.ERROR, (ev) => {
         reject(`Failed to load Mss Player`);
@@ -49,51 +29,6 @@ export default class MssPlayer extends BaseTech {
   get isLive() {
     return this.mediaPlayer.isDynamic();
   }
-
-  get audioTrack() {
-    let audioTrackId = '0';
-    let track = this.mediaPlayer.getCurrentTrackFor('audio');
-    audioTrackId = track.index.toString();
-    return audioTrackId;
-  }
-
-  set audioTrack(id) {
-    let audioTracks = this.mediaPlayer.getTracksFor('audio');
-    console.log('set audioTrack(id), id=', id);
-    let track = audioTracks.find((t) => t.index === parseInt(id));
-    console.log('Imma Try to set this track,', track);
-    console.log('Codex BufferSink Error now?');
-
-    this.mediaPlayer.setCurrentTrack(track);
-  }
-
-  get audioTracks() {
-    return this.state.audioTracks;
-  }
-
-  // get textTrack() {
-
-  // }
-
-  // set textTrack(id) {
-
-  // }
-
-  // get textTracks() {
-
-  // }
-
-  // set currentLevel(level: IVideoLevel) {
-
-  // }
-
-  // get currentLevel() {
-
-  // }
-
-  // getVideoLevels() {
-
-  // }
 
   destroy() {
     if (this.mediaPlayer) {

--- a/packages/core/src/tech/HlsJsTech.ts
+++ b/packages/core/src/tech/HlsJsTech.ts
@@ -34,6 +34,12 @@ export default class HlsJsTech extends BaseTech {
       Hls.Events.AUDIO_TRACK_SWITCHED,
       this.onAudioTrackChange.bind(this)
     );
+
+    this.hls.on(
+      Hls.Events.SUBTITLE_TRACK_SWITCH,
+      this.onTextTrackChange.bind(this)
+    );
+
     this.hls.on(Hls.Events.LEVEL_LOADED, this.onLevelLoaded.bind(this));
   }
 
@@ -150,13 +156,32 @@ export default class HlsJsTech extends BaseTech {
         enabled: this.audioTrack === audioTrack.id.toString(),
       })) || []
     )
-      .reverse() // if there are duplicate languages the latest should be kept
-      .filter(
-        (track, index, arr) =>
-          arr.findIndex(
-            (comparisonTrack) => track.language === comparisonTrack.language
-          ) === index
-      );
+  }
+
+  get textTrack() {
+    return this.hls?.subtitleTrack?.toString();
+  }
+
+  set textTrack(id) {
+    if (this.hls) {
+      if (!id) {
+        this.hls.subtitleTrack = -1;
+      } else {
+        this.hls.subtitleTrack = parseInt(id);
+      }
+
+    }
+  }
+
+  get textTracks() {
+    return (
+      this.hls?.subtitleTracks.map(textTrack => ({
+        id: textTrack.id.toString(),
+        label: textTrack.name,
+        language: textTrack.lang,
+        enabled: this.textTrack === textTrack.id.toString(),
+      })) || []
+    )
   }
 
   seekToLive() {

--- a/packages/core/src/tech/ShakaTech.ts
+++ b/packages/core/src/tech/ShakaTech.ts
@@ -40,12 +40,45 @@ export default class DashPlayer extends BaseTech {
   }
 
   get audioTracks() {
-    return this.shakaPlayer?.getAudioLanguages().map((audioLang) => ({
-      id: audioLang,
-      language: audioLang,
-      label: audioLang,
-      enabled: this.audioTrack === audioLang,
-    }));
+    console.log("....:::::..:::.::::.:::\n " + JSON.stringify(this.shakaPlayer.selectVariantsByLabel("Surround")));
+    this.shakaPlayer?.getVariantTracks().map(at => console.log("MPD audioTracks: \n" + JSON.stringify(at)));
+    //this.shakaPlayer?.getAudioLanguagesAndRoles().map( at => console.log("MPD audio and roles: \n" + JSON.stringify(at)));
+    //this.shakaPlayer?.getAudioLanguages().map( at => console.log("MPD only audiolangs: \n" + JSON.stringify(at)));
+    // this.shakaPlayer?.getTextTracks().map(at => console.log("MPD TextTracks: \n" + JSON.stringify(at)));
+    //this.shakaPlayer?.getTextLanguagesAndRoles().map(at => console.log("MPD TextL&R: \n" + JSON.stringify(at)));
+    return this.shakaPlayer?.getAudioLanguagesAndRoles().map((audioTrack) => ({
+      id: audioTrack.language,
+      label: audioTrack.label ? audioTrack.label : audioTrack.language,
+      language: audioTrack.language,
+      enabled: this.audioTrack === audioTrack.language,
+    }))
+  }
+
+  get textTrack() {
+    return this.shakaPlayer?.getTextTracks()?.find((track) => track.active)
+      ?.language;
+  }
+
+  set textTrack(id) {
+    if (this.shakaPlayer) {
+      if (!id) {
+        this.shakaPlayer.setTextTrackVisibility(false);
+      } else {
+        this.shakaPlayer.setTextTrackVisibility(true);
+        this.shakaPlayer.selectTextLanguage(id);
+      }
+    }
+  }
+
+  get textTracks() {
+    return this.shakaPlayer?.getTextLanguagesAndRoles()
+      .filter((textTrack: any) => textTrack.kind !== 'metadata')
+      .map(track => ({
+        id: track.language,
+        label: track.label ? track.label : track.language,
+        language: track.language,
+        enabled: this.textTrack === track.language,
+      }));
   }
 
   set currentLevel(level: IVideoLevel) {

--- a/packages/core/src/tech/ShakaTech.ts
+++ b/packages/core/src/tech/ShakaTech.ts
@@ -40,45 +40,12 @@ export default class DashPlayer extends BaseTech {
   }
 
   get audioTracks() {
-    console.log("....:::::..:::.::::.:::\n " + JSON.stringify(this.shakaPlayer.selectVariantsByLabel("Surround")));
-    this.shakaPlayer?.getVariantTracks().map(at => console.log("MPD audioTracks: \n" + JSON.stringify(at)));
-    //this.shakaPlayer?.getAudioLanguagesAndRoles().map( at => console.log("MPD audio and roles: \n" + JSON.stringify(at)));
-    //this.shakaPlayer?.getAudioLanguages().map( at => console.log("MPD only audiolangs: \n" + JSON.stringify(at)));
-    // this.shakaPlayer?.getTextTracks().map(at => console.log("MPD TextTracks: \n" + JSON.stringify(at)));
-    //this.shakaPlayer?.getTextLanguagesAndRoles().map(at => console.log("MPD TextL&R: \n" + JSON.stringify(at)));
-    return this.shakaPlayer?.getAudioLanguagesAndRoles().map((audioTrack) => ({
-      id: audioTrack.language,
-      label: audioTrack.label ? audioTrack.label : audioTrack.language,
-      language: audioTrack.language,
-      enabled: this.audioTrack === audioTrack.language,
-    }))
-  }
-
-  get textTrack() {
-    return this.shakaPlayer?.getTextTracks()?.find((track) => track.active)
-      ?.language;
-  }
-
-  set textTrack(id) {
-    if (this.shakaPlayer) {
-      if (!id) {
-        this.shakaPlayer.setTextTrackVisibility(false);
-      } else {
-        this.shakaPlayer.setTextTrackVisibility(true);
-        this.shakaPlayer.selectTextLanguage(id);
-      }
-    }
-  }
-
-  get textTracks() {
-    return this.shakaPlayer?.getTextLanguagesAndRoles()
-      .filter((textTrack: any) => textTrack.kind !== 'metadata')
-      .map(track => ({
-        id: track.language,
-        label: track.label ? track.label : track.language,
-        language: track.language,
-        enabled: this.textTrack === track.language,
-      }));
+    return this.shakaPlayer?.getAudioLanguages().map((audioLang) => ({
+      id: audioLang,
+      language: audioLang,
+      label: audioLang,
+      enabled: this.audioTrack === audioLang,
+    }));
   }
 
   set currentLevel(level: IVideoLevel) {

--- a/packages/core/src/util/constants.ts
+++ b/packages/core/src/util/constants.ts
@@ -29,6 +29,7 @@ export enum PlayerEvent {
 
 	STATE_CHANGE = 'state_change',
 	AUDIO_TRACK_CHANGE = 'audio_track_change',
+	TEXT_TRACK_CHANGE = 'text_track_change',
 	BUFFERING = 'buffering',
 	LIVE_ENDED = 'live_ended',
 }

--- a/packages/demo/src/index.js
+++ b/packages/demo/src/index.js
@@ -87,6 +87,16 @@ async function main() {
       }
     }
 
+    // DEV_PLAYGROUND ::::::::::::::::::::::::::::::..
+    const atrack = player.getAudioTrack_DEV();
+    console.log(`atrack=${atrack}`)
+    const atracks = player.getAudioTracks_DEV();
+    // const ttracks = player.getTextTracks_DEV();
+    console.log(`..:::__|__:::.. INDEX atracks=${JSON.stringify(atracks)}`)
+
+    //::::::::::::::::::::::::::::::::::::::::::::::..
+
+
     const videoLevels = player.getVideoLevels();
     videoLevels.forEach((level, index) => {
       const option = document.createElement('option');
@@ -104,7 +114,7 @@ async function main() {
   };
   dashButton.onclick = async () => {
     manifestInput.value =
-      'https://storage.googleapis.com/shaka-demo-assets/sintel-mp4-only/dash.mpd';
+    'https://dash.akamaized.net/dash264/TestCasesIOP41/MultiTrack/alternative_content/6/manifest_alternative_lang.mpd';//'https://storage.googleapis.com/shaka-demo-assets/sintel-mp4-only/dash.mpd';
     load();
   };
 
@@ -126,9 +136,7 @@ async function main() {
       player.currentLevel = null;
     } else {
       const selectedLevel = player.getVideoLevels()[qualityPicker.value];
-      console.log(
-        `Switching from level ${player.currentLevel.id} to ${selectedLevel.id}`
-      );
+      console.log(`Switching from level ${player.currentLevel.id} to ${selectedLevel.id}`);
       player.currentLevel = selectedLevel;
     }
   };

--- a/packages/demo/src/index.js
+++ b/packages/demo/src/index.js
@@ -87,16 +87,6 @@ async function main() {
       }
     }
 
-    // DEV_PLAYGROUND ::::::::::::::::::::::::::::::..
-    const atrack = player.getAudioTrack_DEV();
-    console.log(`atrack=${atrack}`)
-    const atracks = player.getAudioTracks_DEV();
-    // const ttracks = player.getTextTracks_DEV();
-    console.log(`..:::__|__:::.. INDEX atracks=${JSON.stringify(atracks)}`)
-
-    //::::::::::::::::::::::::::::::::::::::::::::::..
-
-
     const videoLevels = player.getVideoLevels();
     videoLevels.forEach((level, index) => {
       const option = document.createElement('option');
@@ -114,7 +104,7 @@ async function main() {
   };
   dashButton.onclick = async () => {
     manifestInput.value =
-    'https://dash.akamaized.net/dash264/TestCasesIOP41/MultiTrack/alternative_content/6/manifest_alternative_lang.mpd';//'https://storage.googleapis.com/shaka-demo-assets/sintel-mp4-only/dash.mpd';
+    'https://storage.googleapis.com/shaka-demo-assets/sintel-mp4-only/dash.mpd';
     load();
   };
 


### PR DESCRIPTION
To address #10,

This PR makes changes to the HLS part of the web player, so that tracks of same `language`  do not get filtered out, with only one remaining. Now all tracks are included in the tracklist, labeled via each tracks name attribute. HLS standard requires names to be unique. 

I have also implemented HLS support for text tracks. Same thing here. All are included in the tracklist and are labeled by the name attribute.