### PR TITLE
fix: add async attribute for script tag in embed HTML code

### DIFF
--- a/packages/demo/src/index.js
+++ b/packages/demo/src/index.js
@@ -167,7 +167,7 @@ async function main() {
   };
 
   embedButton.onclick = () => {
-    const embedString = `<script type="text/javascript" src="https://unpkg.com/@eyevinn/web-player-component@0.3.1/dist/web-player.component.js"></script>
+    const embedString = `<script async type="text/javascript" src="https://unpkg.com/@eyevinn/web-player-component@0.3.1/dist/web-player.component.js"></script>
     <eyevinn-video source="${manifestInput.value}" muted autoplay ></eyevinn-video>`;
     updateEmbedStatus('Copy this code ➡️');
     embedPopUp(embedString);


### PR DESCRIPTION
This PR addresses #36 and adds the `async` attribute to the script tag in the HTML embed code that is suggested on the demo site. Adding this attribute speeds up page loading as it can be done in parallell to other page requests.