### PR TITLE
fix: do not try to deinit analytics that is not fully loaded yet

### DIFF
--- a/packages/demo/src/index.js
+++ b/packages/demo/src/index.js
@@ -100,15 +100,22 @@ async function main() {
   // Uncomment out this if you want to demo the player package
   // const player = webplayer(root);
 
+  let analyticsInitiated = false;
+
   async function load() {
     await player.load(manifestInput.value);
-    await playerAnalytics.init({
-      sessionId: `demo-page-${Date.now()}`,
-      live: player.isLive,
-      contentId: manifestInput.value,
-      contentUrl: manifestInput.value,
-    });
-    playerAnalytics.load(video);
+    try {
+      await playerAnalytics.init({
+        sessionId: `demo-page-${Date.now()}`,
+        live: player.isLive,
+        contentId: manifestInput.value,
+        contentUrl: manifestInput.value,
+      });
+      playerAnalytics.load(video);
+      analyticsInitiated = true;
+    } catch (err) {
+      console.error(err);
+    }
     populateQualityPicker();
   }
 
@@ -246,7 +253,8 @@ async function main() {
   });
 
   player.on(PlayerEvent.UNREADY, () => {
-    playerAnalytics.deinit();
+    analyticsInitiated && playerAnalytics.deinit();
+    analyticsInitiated = false;
   });
 }
 window.onload = main;


### PR DESCRIPTION
This PR addresses the issue in #39 

What happens is that the player implementation calls `deinit()` when `playerAnalytics.load()` has not been called yet as the `playerAnalytics.init()` throws an exception. The solution in this PR might be a workaround for an issue that perhaps should be handled in the EPAS SDK, however it is a general good thing to catch exceptions...