### PR TITLE
Adjusted media queries to prevent text overflow

### DIFF
--- a/packages/demo/src/style.css
+++ b/packages/demo/src/style.css
@@ -36,12 +36,13 @@ video {
 
 .input-section .input-buttons .input-button, .input-section .input-buttons .autoplay-wrapper {
 	font-size: 1em;
-	width: 10em;
-	margin: 0.5em;
+	width: 10.5em;
+	height: 2.15em;
+	margin: 0.5em 0.3em;
 	display: flex;
 	align-items: center;
 	justify-content: center;
-	min-width: 5.5em;
+	min-width: 10.3em;
 }
 
 @media (max-width: 790px) {
@@ -52,12 +53,13 @@ video {
 @media (max-width: 615px) {
 	.input-section .input-buttons .input-button, .input-section .input-buttons .autoplay-wrapper {
 		width: 44%;
+		font-size: 0.95em;
 	}
 }
-@media (max-width: 340px) {
+@media (max-width: 405px) {
 	.input-section .input-buttons .input-button, .input-section .input-buttons .autoplay-wrapper {
 		width: 100%;
-		height: 2.15em;
+		font-size: 1em;
 	}
 }
 


### PR DESCRIPTION
The text "Copy code below" overflowed at certain viewport sizes before
Also set the height of buttons, as it was inconsistent between buttons when resizing
Changed min-width to accommodate the "Copy code below"-text also with very narrow viewport