### PR TITLE
chore: bump webrtc player version

### DIFF
--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -9,7 +9,7 @@
 			"version": "0.12.0",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@eyevinn/webrtc-player": "^0.5.1",
+				"@eyevinn/webrtc-player": "^0.6.1",
 				"dashjs": "^3.2.2",
 				"hls.js": "^1.1.4",
 				"mitt": "^2.1.0",
@@ -586,12 +586,18 @@
 			"dev": true
 		},
 		"node_modules/@eyevinn/webrtc-player": {
-			"version": "0.5.1",
-			"resolved": "https://registry.npmjs.org/@eyevinn/webrtc-player/-/webrtc-player-0.5.1.tgz",
-			"integrity": "sha512-QH6GhyzNfT84s0gRIt38s5riPgo7NyTvD1dKrRzVPTkP4y1ViHt4KSeWkOYuDHH38JCfVmk8CIT2tA+vhEnfJw==",
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/@eyevinn/webrtc-player/-/webrtc-player-0.6.1.tgz",
+			"integrity": "sha512-MTGJ6KENg8VzInm8XifpF07qHPv2ETXsQ+oddD7AkweAYca9ROpukGmaY3MPy9eem+iyLHJVoszMQoDfrD8i6w==",
 			"dependencies": {
+				"@eyevinn/whpp-client": "^0.1.1",
 				"events": "^3.3.0"
 			}
+		},
+		"node_modules/@eyevinn/whpp-client": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/@eyevinn/whpp-client/-/whpp-client-0.1.1.tgz",
+			"integrity": "sha512-lTCSAQN6IKSflAiTsYpuVvm3+0VQsFC9PlC+z2SL66qS2nOSyQ73i2FXVCknPYqkkmt8bo/s7vXth/Hs4gX/aA=="
 		},
 		"node_modules/@istanbuljs/load-nyc-config": {
 			"version": "1.1.0",
@@ -5068,12 +5074,18 @@
 			"dev": true
 		},
 		"@eyevinn/webrtc-player": {
-			"version": "0.5.1",
-			"resolved": "https://registry.npmjs.org/@eyevinn/webrtc-player/-/webrtc-player-0.5.1.tgz",
-			"integrity": "sha512-QH6GhyzNfT84s0gRIt38s5riPgo7NyTvD1dKrRzVPTkP4y1ViHt4KSeWkOYuDHH38JCfVmk8CIT2tA+vhEnfJw==",
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/@eyevinn/webrtc-player/-/webrtc-player-0.6.1.tgz",
+			"integrity": "sha512-MTGJ6KENg8VzInm8XifpF07qHPv2ETXsQ+oddD7AkweAYca9ROpukGmaY3MPy9eem+iyLHJVoszMQoDfrD8i6w==",
 			"requires": {
+				"@eyevinn/whpp-client": "^0.1.1",
 				"events": "^3.3.0"
 			}
+		},
+		"@eyevinn/whpp-client": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/@eyevinn/whpp-client/-/whpp-client-0.1.1.tgz",
+			"integrity": "sha512-lTCSAQN6IKSflAiTsYpuVvm3+0VQsFC9PlC+z2SL66qS2nOSyQ73i2FXVCknPYqkkmt8bo/s7vXth/Hs4gX/aA=="
 		},
 		"@istanbuljs/load-nyc-config": {
 			"version": "1.1.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -32,7 +32,7 @@
     "ts-jest": "^27.1.2"
   },
   "dependencies": {
-    "@eyevinn/webrtc-player": "^0.5.1",
+    "@eyevinn/webrtc-player": "^0.6.1",
     "dashjs": "^3.2.2",
     "hls.js": "^1.1.4",
     "mitt": "^2.1.0",


### PR DESCRIPTION
Include latest version of webrtc player library that in turn uses the WHPP client library