### PR TITLE
feat!: Disable EPAS by default in web-player-component

### DIFF
--- a/packages/web-player-component/README.md
+++ b/packages/web-player-component/README.md
@@ -11,7 +11,7 @@ This web component is powered by the Eyevinn WebPlayer and can be used on an HTM
 | `autoplay`               | autoplay | Specifies that the video will start playing as soon as it is ready |
 | `muted`                  | muted    | Specifies that the audio output of the video should be muted       |
 | `autoplay-visible`       | autoplay-visible | Specifies that the video will start playing as soon as it is ready and only when visible (pauses when not visible) |
-| `incognito`              | incognito | Disable player analytics tracking |
+| `analytics`              | analytics | Enable EPAS analytics |
 | `epas-url`               | URL | URL to EPAS eventsink. Default is sink.epas.eyevinn.technology |
 | `disable-level-cap`       | disable   | Disable the player's functionality to limit the resolution of the level playing, to the size of the element   |
 

--- a/packages/web-player-component/src/index.html
+++ b/packages/web-player-component/src/index.html
@@ -25,31 +25,31 @@
         <h1>EPAS (autoplay)</h1>
         <eyevinn-video 
             source="https://maitv-vod.lab.eyevinn.technology/VINN.mp4/master.m3u8"
+            analytics
             muted autoplay>
         </eyevinn-video>
         <h1>Live</h1>
         <eyevinn-video
             source="https://d2fz24s2fts31b.cloudfront.net/out/v1/6484d7c664924b77893f9b4f63080e5d/manifest.m3u8"
-            incognito
+            analytics
             muted autoplay>
         </eyevinn-video>
-        <h1>Incognito (no EPAS)</h1>
+        <h1>No analytics</h1>
         <eyevinn-video 
             source="https://lab.cdn.eyevinn.technology/stswe19-three-roads-to-jerusalem.mp4/manifest.m3u8" 
-            starttime="25" 
-            incognito>
+            starttime="25">
         </eyevinn-video>
         <h1>Broken EPAS url</h1>
         <eyevinn-video 
-            source="https://lab.cdn.eyevinn.technology/stswe19-three-roads-to-jerusalem.mp4/manifest.m3u8" 
+            source="https://lab.cdn.eyevinn.technology/stswe19-three-roads-to-jerusalem.mp4/manifest.m3u8"
+            analytics 
             epas-url="https://bad-sink.epas.eyevinn.technology/" 
             starttime="25">
         </eyevinn-video>
-        <h1>Autoplay when visible and incognito</h1>
+        <h1>Autoplay when visible and no analytics</h1>
         <eyevinn-video 
             source="https://lab.cdn.eyevinn.technology/stswe19-global-but-local-ott-platform.mp4/manifest.m3u8" 
             starttime="25"
-            incognito
             muted autoplay-visible>
         </eyevinn-video>
     </div>

--- a/packages/web-player-component/src/index.js
+++ b/packages/web-player-component/src/index.js
@@ -12,7 +12,7 @@ const ComponentAttribute = {
   },
   STATIC: {
     AUTOPLAY_VISIBLE: 'autoplay-visible',
-    INCOGNITO: 'incognito',
+    ANALYTICS: 'analytics',
     EPAS_URL: 'epas-url',
     DISABLE_LEVEL_CAP: 'disable-level-cap',
   }
@@ -40,7 +40,7 @@ export default class PlayerComponent extends HTMLElement {
     this.setupPlayer(wrapper, disablePlayerSizeLevelCap);
 
     this.setupAnalytics({
-      incognito: this.getAttribute(ComponentAttribute.STATIC.INCOGNITO),
+      enabled: this.getAttribute(ComponentAttribute.STATIC.ANALYTICS),
       epasUrl: this.getAttribute(ComponentAttribute.STATIC.EPAS_URL)
     });
 
@@ -76,9 +76,9 @@ export default class PlayerComponent extends HTMLElement {
     });
   }
 
-  setupAnalytics({ incognito, epasUrl }) {
+  setupAnalytics({ enabled, epasUrl }) {
     this.playerAnalytics = null;
-    if (!isSet(incognito)) {
+    if (isSet(enabled)) {
       this.playerAnalytics = new PlayerAnalyticsConnector(epasUrl || "https://sink.epas.eyevinn.technology");
     }
   }

--- a/packages/web-player-component/webpack.config.js
+++ b/packages/web-player-component/webpack.config.js
@@ -5,6 +5,11 @@ const webpack = require('webpack');
 
 module.exports = {
   mode: 'production',
+  performance: {
+    hints: false,
+    maxEntrypointSize: 2512000,
+    maxAssetSize: 2512000
+  },
   entry: './src/index.js',
   output: {
     library: 'webplayer.component',


### PR DESCRIPTION
With this PR EPAS analytics is disabled by default in the web-player-component and removed the `incognito` attribute in favor of the new attribute `analytics`